### PR TITLE
Preventing spam with CLIENT_PACKETS.KEY

### DIFF
--- a/src/browser-impl/user-input/keyboard-and-mouse-input.ts
+++ b/src/browser-impl/user-input/keyboard-and-mouse-input.ts
@@ -185,7 +185,7 @@ export class KeyboardAndMouseInput {
 
         }
 
-        if (keyToSend) {
+        if (keyToSend && !e.repeat) {
             this.context.eventQueue.pub(Events.KEYBOARD, { key: keyToSend, state: isKeyDown } as IKeyboardArgs);
         }
 


### PR DESCRIPTION
Depending on the keyboard setting, the client can create many repeated (and not necessary) KEY packets, which causes the server to broadcast many PLAYER_UPDATE packets. In fact, it's enough to send only one KEY packet after key status update.

Thanks xplay (@TakenOrNot) for pointing out the issue.